### PR TITLE
Allow files to be selected in the Project view

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -47,6 +47,7 @@
 				text="Show Bytecode outline"
 				description="Shows the bytecode outline and ASMified code from the current class">
 			<add-to-group group-id="EditorPopupMenu" anchor="last"/>
+			<add-to-group group-id="ProjectViewPopupMenu" anchor="last"/>
             <add-to-group group-id="CodeMenu" anchor="last"/>
 		</action>
 	</actions>

--- a/src/org/objectweb/asm/idea/ShowBytecodeOutlineAction.java
+++ b/src/org/objectweb/asm/idea/ShowBytecodeOutlineAction.java
@@ -18,14 +18,16 @@
 
 package org.objectweb.asm.idea;
 
-import com.intellij.openapi.actionSystem.*;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.PlatformDataKeys;
+import com.intellij.openapi.actionSystem.Presentation;
 import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.compiler.CompileContext;
 import com.intellij.openapi.compiler.CompileScope;
 import com.intellij.openapi.compiler.CompileStatusNotification;
 import com.intellij.openapi.compiler.CompilerManager;
-import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtil;
@@ -59,15 +61,10 @@ public class ShowBytecodeOutlineAction extends AnAction {
 
     @Override
     public void update(final AnActionEvent e) {
-        final Editor editor = e.getData(PlatformDataKeys.EDITOR);
         final VirtualFile virtualFile = e.getData(PlatformDataKeys.VIRTUAL_FILE);
+        final Project project = e.getData(PlatformDataKeys.PROJECT);
         final Presentation presentation = e.getPresentation();
-        if (editor == null || virtualFile == null) {
-            presentation.setEnabled(false);
-            return;
-        }
-        final Project project = editor.getProject();
-        if (project == null) {
+        if (project == null || virtualFile == null) {
             presentation.setEnabled(false);
             return;
         }
@@ -76,10 +73,8 @@ public class ShowBytecodeOutlineAction extends AnAction {
     }
 
     public void actionPerformed(AnActionEvent e) {
-        final Editor editor = e.getData(PlatformDataKeys.EDITOR);
         final VirtualFile virtualFile = e.getData(PlatformDataKeys.VIRTUAL_FILE);
-        if (editor == null) return;
-        final Project project = editor.getProject();
+        final Project project = e.getData(PlatformDataKeys.PROJECT);
         if (project == null || virtualFile == null) return;
         final PsiFile psiFile = PsiManager.getInstance(project).findFile(virtualFile);
         if (psiFile instanceof PsiClassOwner) {
@@ -99,7 +94,7 @@ public class ShowBytecodeOutlineAction extends AnAction {
                 final Application application = ApplicationManager.getApplication();
                 application.runWriteAction(new Runnable() {
                     public void run() {
-                        FileDocumentManager.getInstance().saveDocument(editor.getDocument());
+                        FileDocumentManager.getInstance().saveAllDocuments();
                     }
                 });
                 application.executeOnPooledThread(new Runnable() {


### PR DESCRIPTION
This patch allows files to be selected in the Project view. This is useful for selecting class files from external libraries and class files from other languages whose source files don't implement PsiClassOwner (e.g. Clojure).
