### PR TITLE
Fixed resolution of expand frame property

### DIFF
--- a/src/org/objectweb/asm/idea/ShowBytecodeOutlineAction.java
+++ b/src/org/objectweb/asm/idea/ShowBytecodeOutlineAction.java
@@ -233,7 +233,7 @@ public class ShowBytecodeOutlineAction extends AnAction {
                 final ASMPluginComponent config = project.getComponent(ASMPluginComponent.class);
                 if (config.isSkipDebug()) flags = flags | ClassReader.SKIP_DEBUG;
                 if (config.isSkipFrames()) flags = flags | ClassReader.SKIP_FRAMES;
-                if (config.isSkipCode()) flags = flags | ClassReader.EXPAND_FRAMES;
+                if (config.isExpandFrames()) flags = flags | ClassReader.EXPAND_FRAMES;
                 if (config.isSkipCode()) flags = flags | ClassReader.SKIP_CODE;
 
                 reader.accept(visitor, flags);

--- a/src/org/objectweb/asm/idea/config/ASMPluginComponent.java
+++ b/src/org/objectweb/asm/idea/config/ASMPluginComponent.java
@@ -53,7 +53,7 @@ public class ASMPluginComponent implements ProjectComponent, Configurable, Persi
     private boolean skipFrames = false;
     private boolean skipDebug = false;
     private boolean skipCode = false;
-    private boolean expandFrames;
+    private boolean expandFrames = false;
     private GroovyCodeStyle codeStyle = GroovyCodeStyle.LEGACY;
 
     private ASMPluginConfiguration configDialog;


### PR DESCRIPTION
The `expandFrame` option is resolved incorrectly and tied to the skip code property. This makes it effectively impossible to use the option as frames are only displayed embedded in code.
